### PR TITLE
fix listeners re-adding with share buttons update (2)

### DIFF
--- a/src/share-buttons.js
+++ b/src/share-buttons.js
@@ -135,6 +135,17 @@
             return getAttribute(share, 'data-desc') || (metaDesc && getAttribute(metaDesc, 'content')) || ' ';
         };
 
+        /**
+         * Counter for generated cache's share button's index.
+         * This to reference added share buttons' listeners.
+         */
+        var refCounter = 0
+        /**
+         * List of added listeners' for share buttons.
+         * This to index listeners' for update or removal purpose.
+         */
+        var listenersCache = {}
+
        /**
         * Method for attaching event to the element
         * @param {HTMLElement} el
@@ -145,13 +156,29 @@
             var handler = function () {
                 share(opt.id, opt.url, opt.title, opt.desc);
             };
+            var iehandler = function () {
+                handler.call(el);
+            };
+            var cachedRef = el.getAttribute('data-sharebtn-ref')
+
+            if (cachedRef) {
+                if (el.removeEventListener) {
+                    el.removeEventListener(eventName, listenersCache[cachedRef]);
+                } else {
+                    el.detachEvent('on' + eventName, listenersCache[cachedRef+'ie']);
+                }
+            } else {
+                cachedRef = ++refCounter
+                el.setAttribute('data-sharebtn-ref', cachedRef);
+            }
+
+            listenersCache[cachedRef] = handler
+            listenersCache[cachedRef+'ie'] = iehandler
 
             if (el.addEventListener) {
                 el.addEventListener(eventName, handler);
             } else {
-                el.attachEvent('on' + eventName, function () {
-                    handler.call(el);
-                });
+                el.attachEvent('on' + eventName, iehandler);
             }
         };
 

--- a/src/share-buttons.js
+++ b/src/share-buttons.js
@@ -106,6 +106,7 @@
         var prepareLink = function (el, options) {
             options.id = getAttribute(el, 'data-id');
             if (options.id) {
+                removeEventListener(el, 'click');
                 addEventListener(el, 'click', options);
             }
         };
@@ -147,6 +148,23 @@
         var listenersCache = {}
 
        /**
+        * Method for detaching event to the element
+        * @param {HTMLElement} el
+        * @param {string} eventName
+        */
+        var removeEventListener = function (el, eventName) {
+            var cachedRef = el.getAttribute('data-sharebtn-ref');
+
+            if (cachedRef) {
+                if (el.removeEventListener) {
+                    el.removeEventListener(eventName, listenersCache[cachedRef]);
+                } else {
+                    el.detachEvent('on' + eventName, listenersCache[cachedRef+'ie']);
+                }
+            }
+        };
+
+       /**
         * Method for attaching event to the element
         * @param {HTMLElement} el
         * @param {string} eventName
@@ -159,21 +177,15 @@
             var iehandler = function () {
                 handler.call(el);
             };
-            var cachedRef = el.getAttribute('data-sharebtn-ref')
+            var cachedRef = el.getAttribute('data-sharebtn-ref');
 
-            if (cachedRef) {
-                if (el.removeEventListener) {
-                    el.removeEventListener(eventName, listenersCache[cachedRef]);
-                } else {
-                    el.detachEvent('on' + eventName, listenersCache[cachedRef+'ie']);
-                }
-            } else {
-                cachedRef = ++refCounter
+            if (!cachedRef) {
+                cachedRef = ++refCounter;
                 el.setAttribute('data-sharebtn-ref', cachedRef);
             }
 
-            listenersCache[cachedRef] = handler
-            listenersCache[cachedRef+'ie'] = iehandler
+            listenersCache[cachedRef] = handler;
+            listenersCache[cachedRef+'ie'] = iehandler;
 
             if (el.addEventListener) {
                 el.addEventListener(eventName, handler);


### PR DESCRIPTION
Previous added listeners to share buttons are re-added twice or multiple time when execute `ShareButtons.update()`.
In browsers, if `data-url` or `data-title` or `data-desc` have been changed before calling `ShareButtons.update()`, the changes will not be considered because the previous added listeners *with previous data value* on share buttons will be executed on click event before the new added listeners after `ShareButtons.update()`.
**This pull request aims to fix that**. 

**This is an adjustment regarding requested changes from this PR** #28 