### PR TITLE
Copy link to clipboard & WebShare API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Simple, powerful, customizable and super lightweight (1 Kb Gzip) social buttons 
 
 Copy to clipboard is not supported on IE, see [browser compatibility for more information](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#browser_compatibility)
 
+WebShare API is only partially supported, see [browser compatibility for more information](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#browser_compatibility)
+
 ## Install
 
 ### Available in NPM
@@ -86,6 +88,7 @@ Xing      | xi
 EMail     | mail
 Print     | print
 Copy     | copy
+WebShare API     | shareSheet
 
 ## Customizing
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Simple, powerful, customizable and super lightweight (1 Kb Gzip) social buttons 
 * Android
 * iOS
 
+Copy to clipboard is not supported on IE, see [browser compatibility for more information](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#browser_compatibility)
+
 ## Install
 
 ### Available in NPM
@@ -83,6 +85,7 @@ Hacker News | hn
 Xing      | xi
 EMail     | mail
 Print     | print
+Copy     | copy
 
 ## Customizing
 

--- a/example/index.html
+++ b/example/index.html
@@ -45,6 +45,7 @@
         <a class="btn-xing" data-id="xi"><i class="fab fa-xing"></i> Xing</a>
         <a class="btn-mail" data-id="mail"><i class="fas fa-at"></i> EMail</a>
         <a class="btn-print" data-id="print"><i class="fas fa-print"></i> Print</a>
+        <a class="btn-copy" data-id="copy"><i class="fas fa-copy"></i> Copy</a>
     </div>
 
     <script src="../src/share-buttons.js"></script>

--- a/example/index.html
+++ b/example/index.html
@@ -46,6 +46,7 @@
         <a class="btn-mail" data-id="mail"><i class="fas fa-at"></i> EMail</a>
         <a class="btn-print" data-id="print"><i class="fas fa-print"></i> Print</a>
         <a class="btn-copy" data-id="copy"><i class="fas fa-copy"></i> Copy</a>
+        <a class="btn-shareSheet" data-id="shareSheet"><i class="fas fa-ellipsis-h"></i> ShareSheet</a>
     </div>
 
     <script src="../src/share-buttons.js"></script>

--- a/src/share-buttons.js
+++ b/src/share-buttons.js
@@ -82,7 +82,7 @@
             if(!navigator.clipboard) {
                 var buttons = document.querySelectorAll(`[data-id="${COPY_CLASS_NAME}"]`);
                 for (i = 0; i < buttons.length; i++) {
-                    buttons[i].hidden = true;
+                    buttons[i].style.display = 'none';
                 }
                 console.log('navigator.clipboard(): This feature is not supported on this browser or operating system.');
             }
@@ -91,7 +91,7 @@
             if(!navigator.canShare) {
                 var buttons = document.querySelectorAll(`[data-id="${SHARESHEET_CLASS_NAME}"]`);
                 for (i = 0; i < buttons.length; i++) {
-                    buttons[i].hidden = true;
+                    buttons[i].style.display = 'none';
                 }
                 console.log('navigator.share(): This feature is not supported on this browser or operating system.');
             }

--- a/src/share-buttons.js
+++ b/src/share-buttons.js
@@ -44,7 +44,8 @@
             HN_CLASS_NAME = 'hn',
             XI_CLASS_NAME = 'xi',
             MAIL_CLASS_NAME = 'mail',
-            PRINT_CLASS_NAME = 'print';
+            PRINT_CLASS_NAME = 'print',
+            COPY_CLASS_NAME = 'copy';
 
         /**
          * Method for get string in the special format by arguments
@@ -74,6 +75,15 @@
 
             for (i = share.length; i--;) {
                 initForElement(share[i]);
+            }
+
+            // Check if navigator.clipboard is supported. If not, hide all shareSheet buttons.
+            if(!navigator.clipboard) {
+                var buttons = document.querySelectorAll(`[data-id="${COPY_CLASS_NAME}"]`);
+                for (i = 0; i < buttons.length; i++) {
+                    buttons[i].hidden = true;
+                }
+                console.log('navigator.clipboard(): This feature is not supported on this browser or operating system.');
             }
         };
 
@@ -206,6 +216,14 @@
          */
         var encode = function (text) {
             return encodeURIComponent(text);
+        };
+
+        /**
+         * Method for decoding URL format to text
+         * @param {string} text
+         */
+        var decode = function (text) {
+            return decodeURIComponent(text);
         };
 
         /**
@@ -359,6 +377,10 @@
 
             case PRINT_CLASS_NAME:
                 window.print();
+                break;
+
+            case COPY_CLASS_NAME:
+                navigator.clipboard.writeText(decode(url));
                 break;
 
             default:

--- a/src/share-buttons.js
+++ b/src/share-buttons.js
@@ -45,7 +45,8 @@
             XI_CLASS_NAME = 'xi',
             MAIL_CLASS_NAME = 'mail',
             PRINT_CLASS_NAME = 'print',
-            COPY_CLASS_NAME = 'copy';
+            COPY_CLASS_NAME = 'copy',
+            SHARESHEET_CLASS_NAME = 'shareSheet';
 
         /**
          * Method for get string in the special format by arguments
@@ -84,6 +85,15 @@
                     buttons[i].hidden = true;
                 }
                 console.log('navigator.clipboard(): This feature is not supported on this browser or operating system.');
+            }
+
+            // Check if navigator.share is supported. If not, hide all shareSheet buttons.
+            if(!navigator.canShare) {
+                var buttons = document.querySelectorAll(`[data-id="${SHARESHEET_CLASS_NAME}"]`);
+                for (i = 0; i < buttons.length; i++) {
+                    buttons[i].hidden = true;
+                }
+                console.log('navigator.share(): This feature is not supported on this browser or operating system.');
             }
         };
 
@@ -381,6 +391,21 @@
 
             case COPY_CLASS_NAME:
                 navigator.clipboard.writeText(decode(url));
+                break;
+
+            case SHARESHEET_CLASS_NAME:
+                text = decode(mergeForTitle([title, desc]));
+                var shareData = {
+                    title: text,
+                    text: text,
+                    url: decode(url),
+                };
+
+                navigator.share(shareData).then(() => {
+                    console.log('navigator.share(): Success');
+                }).catch((err) => {
+                    console.log('navigator.share(): Error', err);
+                });
                 break;
 
             default:


### PR DESCRIPTION
I added support for copying the link to the clipboard. IFAIK only IE doesn't support this, see [browser compatibility for more information](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#browser_compatibility). If the feature is not supported on the browser, the "copy" buttons should automatically hide.

I also added support for WebShare API but it's only partially supported depending on the OS and browser, see [browser compatibility for more information](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share#browser_compatibility). If the feature is not supported on the browser, the "share to..." buttons should automatically hide.

Issues: #10 
In a way, #21 is supported if you are on mobile with the Instagram app installed.